### PR TITLE
Debug non-clickable website icons

### DIFF
--- a/ios/js/navigation.js
+++ b/ios/js/navigation.js
@@ -133,11 +133,14 @@ class iOSNavigation {
         // Home indicator gesture
         this.setupHomeGesture();
         
-        // Prevent default touch behaviors on device
+        // Prevent default touch behaviors on device (but allow app interactions)
         const device = document.querySelector('.ios-device');
         if (device) {
             device.addEventListener('touchstart', (e) => {
-                e.preventDefault();
+                // Only prevent default for non-interactive elements
+                if (!e.target.closest('.ios-app') && !e.target.closest('.ios-dock-app') && !e.target.closest('.ios-home-indicator')) {
+                    e.preventDefault();
+                }
             }, { passive: false });
         }
     }
@@ -152,18 +155,15 @@ class iOSNavigation {
             if (appClass && this.apps[appClass]) {
                 app.addEventListener('click', (e) => {
                     console.log('App clicked:', appClass);
-                    e.preventDefault();
                     this.launchApp(appClass);
                 });
                 
                 // Add touch feedback
                 app.addEventListener('touchstart', (e) => {
-                    e.preventDefault();
                     this.addTouchFeedback(app);
                 });
                 
                 app.addEventListener('touchend', (e) => {
-                    e.preventDefault();
                     this.removeTouchFeedback(app);
                 });
             }
@@ -184,12 +184,10 @@ class iOSNavigation {
                 
                 // Add touch feedback
                 app.addEventListener('touchstart', (e) => {
-                    e.preventDefault();
                     this.addTouchFeedback(app);
                 });
                 
                 app.addEventListener('touchend', (e) => {
-                    e.preventDefault();
                     this.removeTouchFeedback(app);
                 });
             }

--- a/ios_debug_summary.md
+++ b/ios_debug_summary.md
@@ -1,0 +1,75 @@
+# iOS Icons Click Issue - Debug Summary
+
+## Issues Found and Fixed
+
+### 1. Touch Event Prevention Issue
+**Problem**: The device container was preventing ALL touch events with `e.preventDefault()`, which blocked click events on app icons.
+
+**Fix**: Modified the touch event handler to only prevent default for non-interactive elements:
+```javascript
+// Before
+device.addEventListener('touchstart', (e) => {
+    e.preventDefault();
+}, { passive: false });
+
+// After  
+device.addEventListener('touchstart', (e) => {
+    // Only prevent default for non-interactive elements
+    if (!e.target.closest('.ios-app') && !e.target.closest('.ios-dock-app') && !e.target.closest('.ios-home-indicator')) {
+        e.preventDefault();
+    }
+}, { passive: false });
+```
+
+### 2. Touch Feedback Event Prevention
+**Problem**: Touch feedback handlers were calling `e.preventDefault()` which could interfere with click events.
+
+**Fix**: Removed `e.preventDefault()` from touch feedback handlers:
+```javascript
+// Before
+app.addEventListener('touchstart', (e) => {
+    e.preventDefault();
+    this.addTouchFeedback(app);
+});
+
+// After
+app.addEventListener('touchstart', (e) => {
+    this.addTouchFeedback(app);
+});
+```
+
+### 3. Click Event Prevention
+**Problem**: Click event handlers were calling `e.preventDefault()` unnecessarily.
+
+**Fix**: Removed `e.preventDefault()` from click handlers:
+```javascript
+// Before
+app.addEventListener('click', (e) => {
+    console.log('App clicked:', appClass);
+    e.preventDefault();
+    this.launchApp(appClass);
+});
+
+// After
+app.addEventListener('click', (e) => {
+    console.log('App clicked:', appClass);
+    this.launchApp(appClass);
+});
+```
+
+## Testing
+
+Created `test_click_debug.html` to verify click functionality works independently.
+
+## Expected Results
+
+After these fixes:
+1. App icons should be clickable
+2. Console should show "App clicked: [app-name]" messages
+3. Apps should launch with slide-in animation
+4. Touch feedback should work without interfering with clicks
+
+## Files Modified
+
+- `ios/js/navigation.js` - Fixed touch and click event handling
+- `test_click_debug.html` - Created for testing (can be deleted)


### PR DESCRIPTION
Enable app icon clicks and launches by removing unnecessary `e.preventDefault()` calls.

The `e.preventDefault()` calls on the device container, click handlers, and touch feedback events were inadvertently blocking the propagation of click events, preventing app icons from being interactive.

---
<a href="https://cursor.com/background-agent?bcId=bc-c583c77e-bc83-478e-b1b1-34ae8e221b47">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c583c77e-bc83-478e-b1b1-34ae8e221b47">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

