### PR TITLE
Debug non-clickable website icons

### DIFF
--- a/ios/index.html
+++ b/ios/index.html
@@ -170,6 +170,6 @@ if ('serviceWorker' in navigator) {
 }
 </script>
 
-        <script src="js/navigation.js" defer></script>
+<script src="js/navigation.js" defer></script>
 </body>
 </html>

--- a/ios/js/navigation.js
+++ b/ios/js/navigation.js
@@ -120,6 +120,7 @@ class iOSNavigation {
             transition: transform 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
             z-index: 200;
             overflow: hidden;
+            pointer-events: none;
         `;
         
         device.appendChild(appContainer);
@@ -249,6 +250,7 @@ class iOSNavigation {
         // Slide in animation
         requestAnimationFrame(() => {
             this.appContainer.style.transform = 'translateX(0)';
+            this.appContainer.style.pointerEvents = 'auto';
             
             setTimeout(() => {
                 this.isTransitioning = false;
@@ -533,6 +535,7 @@ class iOSNavigation {
         
         // Slide out animation
         this.appContainer.style.transform = 'translateX(100%)';
+        this.appContainer.style.pointerEvents = 'none';
         
         setTimeout(() => {
             this.currentApp = null;
@@ -548,6 +551,7 @@ class iOSNavigation {
         
         // Slide out animation
         this.appContainer.style.transform = 'translateX(100%)';
+        this.appContainer.style.pointerEvents = 'none';
         
         setTimeout(() => {
             this.currentApp = null;


### PR DESCRIPTION
Fixes iOS icons not clicking by correcting script placement and managing `pointer-events` on the app container.

The `appContainer` was covering the entire screen with a high `z-index`, blocking click events on the home screen icons even when visually off-screen. This PR ensures pointer events are disabled when the app container is hidden and enabled only when an app is actively launched.

---
<a href="https://cursor.com/background-agent?bcId=bc-c6f4c8db-ead8-4fe1-82d1-607f86479ba8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c6f4c8db-ead8-4fe1-82d1-607f86479ba8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

