### PR TITLE
Remove profile icon from news ticker

### DIFF
--- a/wrestling-news/index.html
+++ b/wrestling-news/index.html
@@ -195,7 +195,6 @@
     <div class="news-ticker-container">
         <div class="news-ticker-wrap">
             <div class="news-label">
-                <img src="0sBykTmz_400x400.jpg" alt="Jesse Rodriguez" class="profile-pic">
                 @JesseRodPodcast
             </div>
             <div class="news-content">


### PR DESCRIPTION
Remove the profile icon image from the news feed ticker to eliminate the profile icon holder.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e73d40a-400d-474c-820f-fadff16deff7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1e73d40a-400d-474c-820f-fadff16deff7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

